### PR TITLE
Remove Overkill Consulting ApS

### DIFF
--- a/ix_client.yml
+++ b/ix_client.yml
@@ -78,18 +78,3 @@ clients:
           as_sets:
             - "RIPE::AS198275:AS-ALL"
       16bit_mapped_asn: 64516
-
-  - asn: 198186
-    description: "Overkill Consulting ApS"
-    speed: 1000
-    ip:
-      - "185.0.29.15"
-      - "2001:7f8:149:1ab::19:8186:1"
-    mac: "DC:A6:32:AD:3C:F5"
-    rs_peer: True
-    rs_config:
-      filtering:
-        irrdb:
-          as_sets:
-            - "RIPE::AS198186:AS-PRIMARY"
-      16bit_mapped_asn: 64517


### PR DESCRIPTION
The AS has been de-registered.
The server is still present in labicolo but without BGP setup.